### PR TITLE
Update wallet to 2.0.3.1

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       2
 #define CLIENT_VERSION_MINOR       0
 #define CLIENT_VERSION_REVISION    3
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_BUILD       1
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4519,8 +4519,8 @@ void BitcoinMiner(CWallet *pwallet, bool fProofOfStake)
 
         while (true)
         {
-            // always calculate totalCoins
-            totalCoins = GetTotalCoins();
+            // always calculate totalCoin
+            totalCoin = GetTotalCoin();
             // new block, use groestl
             uint256 hash = pblock->GetHashGroestl();
             if (hash <= hashTarget)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3020,10 +3020,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             return true;
         }
 
-        // Diamond: disconnect any known version prior 2.0.2.1
+        // Diamond: disconnect any known version prior 2.0.3
         // as these have PoS not working and could serve us garbage
         printf("connected subver %s\n", pfrom->strSubVer.c_str());
         if (!strcmp(pfrom->strSubVer.c_str(),"/Diamond:2.0.1/")
+            || !strcmp(pfrom->strSubVer.c_str(),"/Diamond:2.0.2.1/")
             || !strcmp(pfrom->strSubVer.c_str(),"/Diamond:0.7.2/")
             || !strcmp(pfrom->strSubVer.c_str(),"/Satoshi:0.7.2/")
             || !strcmp(pfrom->strSubVer.c_str(),"")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3329,13 +3329,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         // Send the rest of the chain
         if (pindex)
             pindex = pindex->pnext;
-        int nLimit = 500;
+        int nLimit = 500 + locator.GetDistanceBack();
+        unsigned int nBytes = 0;
         printf("getblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20).c_str(), nLimit);
         for (; pindex; pindex = pindex->pnext)
         {
             if (pindex->GetBlockHash() == hashStop)
             {
-                printf("  getblocks stopping at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20).c_str());
+                printf("  getblocks stopping at %d %s (%u bytes)\n", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20).c_str(), nBytes);
                 // ppcoin: tell downloading node about the latest block if it's
                 // without risk being rejected due to stake connection check
                 if (hashStop != hashBestChain && pindex->GetBlockTime() + nStakeMinAge > pindexBest->GetBlockTime())
@@ -3343,11 +3344,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                 break;
             }
             pfrom->PushInventory(CInv(MSG_BLOCK, pindex->GetBlockHash()));
-            if (--nLimit <= 0)
+            CBlock block;
+            block.ReadFromDisk(pindex, true);
+            nBytes += block.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+            if (--nLimit <= 0 || nBytes >= SendBufferSize()/2)
             {
                 // When this block is requested, we'll send an inv that'll make them
                 // getblocks the next batch of inventory.
-                printf("  getblocks stopping at limit %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20).c_str());
+                printf("  getblocks stopping at limit %d %s (%u bytes)\n", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20).c_str(), nBytes);
                 pfrom->hashContinue = pindex->GetBlockHash();
                 break;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2347,8 +2347,19 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
         if (bnNewBlock > bnRequired)
         {
             if (pfrom)
-                pfrom->Misbehaving(100);
-            return error("ProcessBlock() : block with too little %s", pblock->IsProofOfStake()? "proof-of-stake" : "proof-of-work");
+                pfrom->Misbehaving(10); // danbi: was 100, but that's way too heavy handed
+            if (fDebug)
+            {
+                printf("ProcessBlock(): ");
+                pblock->print();
+                printf("\n");
+            }
+            // danbi: Only refuse this block if time distance between the last sync checkpoint 
+            // and the block's time is less than the checkpoints max span
+            if (deltaTime < CHECKPOINT_MAX_SPAN)
+                return error("ProcessBlock() : block with too little %s", pblock->IsProofOfStake()? "proof-of-stake" : "proof-of-work");
+            else
+                return printf("ProcessBlock(CHECKPOINT_MAX_SPAN) : block with too little %s", pblock->IsProofOfStake()? "proof-of-stake" : "proof-of-work");
         }
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -94,7 +94,6 @@ extern bool fUseFastIndex;
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64 nMinDiskSpace = 52428800;
 
-
 class CReserveKey;
 class CTxDB;
 class CTxIndex;
@@ -131,8 +130,6 @@ uint256 WantedByOrphan(const CBlock* pblockOrphan);
 const CBlockIndex* GetLastBlockIndex(const CBlockIndex* pindex, bool fProofOfStake);
 void BitcoinMiner(CWallet *pwallet, bool fProofOfStake);
 void ResendWalletTransactions();
-
-
 
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -26,8 +26,8 @@ extern int nBestHeight;
 
 
 
-inline unsigned int ReceiveBufferSize() { return 1000*GetArg("-maxreceivebuffer", 5*1000); }
-inline unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000); }
+inline unsigned int ReceiveBufferSize() { return 1000*GetArg("-maxreceivebuffer", 10*1000); }
+inline unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 10*1000); }
 
 void AddOneShot(std::string strDest);
 bool RecvLine(SOCKET hSocket, std::string& strLine);

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -63,7 +63,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string notr="true">2.0.3</string>
+          <string notr="true">2.0.3.1</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/version.h
+++ b/src/version.h
@@ -47,6 +47,6 @@ static const int MEMPOOL_GD_VERSION = 60002;
 #define DISPLAY_VERSION_MAJOR       2
 #define DISPLAY_VERSION_MINOR       0
 #define DISPLAY_VERSION_REVISION    3
-#define DISPLAY_VERSION_BUILD       0
+#define DISPLAY_VERSION_BUILD       1
 
 #endif


### PR DESCRIPTION
New in this version:
- disconnect pre 2.0.3 clients;
- dynamic increase of the getblocks queue;
- Fix the 'not enough work' ban logic;
- misc formatting and dead code cleanup.
