### PR TITLE
Update Diamond wallet to 2.0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Update ubuntu
 
 *install the other necessary components
 
-    sudo apt-get install build-essential libboost1.48-all-dev libcurl4-openssl-dev libdb5.1-dev libdb5.1++-dev
+    sudo apt-get install build-essential libboost1.55-all-dev libcurl4-openssl-dev libdb5.1-dev libdb5.1++-dev
 
 *navigate to the home directory
 
     cd ~ *download the diamond source code
 
-    git clone https://github.com/DMDcoin/Diamond-Coin-2.0.1.git
+    git clone https://github.com/DMDcoin/Diamond.git
 
 *navigate to the downloaded files
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       2
 #define CLIENT_VERSION_MINOR       0
 #define CLIENT_VERSION_REVISION    3
-#define CLIENT_VERSION_BUILD       1
+#define CLIENT_VERSION_BUILD       2
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -853,69 +853,115 @@ bool CTxDB::LoadBlockIndexGuts()
         // Unserialize
 
         try {
-        string strType;
-        ssKey >> strType;
-        if (strType == "blockindex" && !fRequestShutdown)
-        {
-            CDiskBlockIndex diskindex;
-            ssValue >> diskindex;
-
-            totalCoin = diskindex.nMoneySupply / COIN;
-            uint256 blockHash = diskindex.GetBlockHash();
-
-            // Construct block index object
-            CBlockIndex* pindexNew = InsertBlockIndex(blockHash);
-            pindexNew->pprev          = InsertBlockIndex(diskindex.hashPrev);
-            pindexNew->pnext          = InsertBlockIndex(diskindex.hashNext);
-            pindexNew->nFile          = diskindex.nFile;
-            pindexNew->nBlockPos      = diskindex.nBlockPos;
-            pindexNew->nHeight        = diskindex.nHeight;
-            pindexNew->nMint          = diskindex.nMint;
-            pindexNew->nMoneySupply   = diskindex.nMoneySupply;
-            pindexNew->nFlags         = diskindex.nFlags;
-            pindexNew->nStakeModifier = diskindex.nStakeModifier;
-            pindexNew->prevoutStake   = diskindex.prevoutStake;
-            pindexNew->nStakeTime     = diskindex.nStakeTime;
-            pindexNew->hashProofOfStake = diskindex.hashProofOfStake;
-            pindexNew->nVersion       = diskindex.nVersion;
-            pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
-            pindexNew->nTime          = diskindex.nTime;
-            pindexNew->nBits          = diskindex.nBits;
-            pindexNew->nNonce         = diskindex.nNonce;
-
-            if(totalCoin == VALUE_CHANGE)
+            string strType;
+            ssKey >> strType;
+            if (strType == "blockindex" && !fRequestShutdown)
             {
-                pindexSave = pindexNew;
+                CDiskBlockIndex diskindex;
+                ssValue >> diskindex;
+
+                totalCoin = diskindex.nMoneySupply / COIN;
+                uint256 blockHash = diskindex.GetBlockHash();
+
+                // clean up junk from the block index
+                if (totalCoin == 0) {
+                    printf("money supply = 0\n");
+                    diskindex.print();
+                    if (blockHash != (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))
+                    {
+                        // not the genesis block, garbage anyway
+                        printf("deleted\n");
+                        continue;
+                    }
+                }
+                if (totalCoin == VALUE_CHANGE) {
+                    printf("height = %d, hash = %s\n", diskindex.nHeight, diskindex.GetBlockHash().ToString().c_str());
+                    diskindex.print();
+                    if (diskindex.hashNext == uint256("0x92134c4608025b6bd945731158391079590d0e7e0c60bd7d09a50c0b0251c6ac"))
+                    {
+                        // assign proper hash value
+                        printf("changed\n");
+                        diskindex.hashNext = uint256("0x00000d652b612a94e1c830bf4e05106438ea6b53372b29206f0b820d91a9b67b");
+                    }
+                    if (diskindex.GetBlockHash() == uint256("0xe12ddb2c35d84403b0a045574ecce223f7e2f0db4506e76ed3d43bc464ace40c"))
+                    {
+                        // this hash version should not be here, delete
+                        printf("deleted\n");
+                        continue;
+                    }
+                }
+                if (totalCoin == VALUE_CHANGE+1) {
+                    // for information
+                    printf("height = %d, hash = %s\n", diskindex.nHeight, diskindex.GetBlockHash().ToString().c_str());
+                    diskindex.print();
+                }
+                // end cleanup
+
+                // Construct block index object
+                CBlockIndex* pindexNew = InsertBlockIndex(blockHash);
+                pindexNew->pprev          = InsertBlockIndex(diskindex.hashPrev);
+                pindexNew->pnext          = InsertBlockIndex(diskindex.hashNext);
+                pindexNew->nFile          = diskindex.nFile;
+                pindexNew->nBlockPos      = diskindex.nBlockPos;
+                pindexNew->nHeight        = diskindex.nHeight;
+                pindexNew->nMint          = diskindex.nMint;
+                pindexNew->nMoneySupply   = diskindex.nMoneySupply;
+                pindexNew->nFlags         = diskindex.nFlags;
+                pindexNew->nStakeModifier = diskindex.nStakeModifier;
+                pindexNew->prevoutStake   = diskindex.prevoutStake;
+                pindexNew->nStakeTime     = diskindex.nStakeTime;
+                pindexNew->hashProofOfStake = diskindex.hashProofOfStake;
+                pindexNew->nVersion       = diskindex.nVersion;
+                pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
+                pindexNew->nTime          = diskindex.nTime;
+                pindexNew->nBits          = diskindex.nBits;
+                pindexNew->nNonce         = diskindex.nNonce;
+
+                if(totalCoin == VALUE_CHANGE)
+                    pindexSave = pindexNew;
+                if(totalCoin == VALUE_CHANGE + 1)
+                    pindexSaveNext = pindexNew;
+
+                // Watch for genesis block
+                if (pindexGenesisBlock == NULL && blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))
+                    pindexGenesisBlock = pindexNew;
+
+                if (!pindexNew->CheckIndex())
+                    return error("LoadBlockIndex() : CheckIndex failed at %d", pindexNew->nHeight);
+
+                // ppcoin: build setStakeSeen
+                if (pindexNew->IsProofOfStake())
+                    setStakeSeen.insert(make_pair(pindexNew->prevoutStake, pindexNew->nStakeTime));
             }
-            if(totalCoin == VALUE_CHANGE + 1)
+            else
             {
-                pindexSaveNext = pindexNew;
+                break; // if shutdown requested or finished loading block index
             }
-
-            // Watch for genesis block
-            if (pindexGenesisBlock == NULL && blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))
-                pindexGenesisBlock = pindexNew;
-
-            if (!pindexNew->CheckIndex())
-                return error("LoadBlockIndex() : CheckIndex failed at %d", pindexNew->nHeight);
-
-            // ppcoin: build setStakeSeen
-            if (pindexNew->IsProofOfStake())
-                setStakeSeen.insert(make_pair(pindexNew->prevoutStake, pindexNew->nStakeTime));
-        }
-        else
-        {
-            break; // if shutdown requested or finished loading block index
-        }
         }    // try
         catch (std::exception &e) {
             return error("%s() : deserialize error", __PRETTY_FUNCTION__);
         }
     }
     if(pindexSaveNext != NULL && pindexSave != NULL && pindexSave->pnext == NULL)
+    {
+        printf("linked pnext at switch block\n");
         pindexSave->pnext = pindexSaveNext;
+    }
 
     pcursor->close();
+
+    printf ("verify mapBlockIndex\n");
+    count=0;
+    BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
+    {
+        CBlockIndex* pindex = item.second;
+        if (pindex->nHeight == 0) {
+	        printf("nHeight=0 count=%d\n", count);
+            pindex->print();
+        }
+        count++;
+    }
+    printf("end verify\n");
 
     return true;
 }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -883,11 +883,11 @@ bool CTxDB::LoadBlockIndexGuts()
             pindexNew->nBits          = diskindex.nBits;
             pindexNew->nNonce         = diskindex.nNonce;
 
-            if(pindexNew->nMoneySupply / COIN == VALUE_CHANGE)
+            if(totalCoin == VALUE_CHANGE)
             {
                 pindexSave = pindexNew;
             }
-            if(pindexNew->nMoneySupply / COIN == VALUE_CHANGE + 1)
+            if(totalCoin == VALUE_CHANGE + 1)
             {
                 pindexSaveNext = pindexNew;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1680,14 +1680,17 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
 		// printf("==> Got prevHash = %s\n", prevHash.ToString().c_str());
 	}
 
+    // danbi: update totalCoin as we are one behind here
+    // XXX: this might backfire in case of error...
+    totalCoin = pindex->nMoneySupply / COIN;
     if(totalCoin <= VALUE_CHANGE)
     {
         if (vtx[0].GetValueOut() > GetProofOfWorkReward(pindex->nHeight, nFees, prevHash))
-            return false;
+            return error("ConnectBlock() : claiming to have created too much (old)");
     }
     else
         if (vtx[0].GetValueOut() > GetProofOfWorkReward(pindex->nHeight, nFees, prevHash) + GetContributionAmount(totalCoin))
-            return false;
+            return error("ConnectBlock() : claiming to have created too much (new)");
 
     if(totalCoin > VALUE_CHANGE && IsProofOfWork())
     {

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -63,7 +63,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string notr="true">2.0.3.1</string>
+          <string notr="true">2.0.3.2</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -505,7 +505,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
 	result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
 	result.push_back(Pair("transactions", transactions));
 	result.push_back(Pair("coinbaseaux", aux));
-        if(totalCoin >= VALUE_CHANGE)
+        if(totalCoin > VALUE_CHANGE)
 	    result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue + (int64_t)pblock->vtx[0].vout[1].nValue));
 	else
 	    result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));

--- a/src/version.h
+++ b/src/version.h
@@ -47,6 +47,6 @@ static const int MEMPOOL_GD_VERSION = 60002;
 #define DISPLAY_VERSION_MAJOR       2
 #define DISPLAY_VERSION_MINOR       0
 #define DISPLAY_VERSION_REVISION    3
-#define DISPLAY_VERSION_BUILD       1
+#define DISPLAY_VERSION_BUILD       2
 
 #endif


### PR DESCRIPTION
This version fixes long standing bugs with hash algorithm switch comparisons and accepting some bogus blocks. Those bogus block hashes should be now eliminated.
It would clean up garbage entries from the block index on load from disk preventing the assert termination.
Some error messages are cleaned up.

Note: this version might use more CPU as it does more hash checks.
