### PR TITLE
Minor fixes and update to version 2.0.4.1

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -402,10 +402,16 @@ bool inline CBitcoinAddressVisitor::operator()(const CNoDestination &id) const {
 class CBitcoinSecret : public CBase58Data
 {
 public:
+    enum
+    {
+        PRIVKEY_ADDRESS = CBitcoinAddress::PUBKEY_ADDRESS + 128,
+        PRIVKEY_ADDRESS_TEST = CBitcoinAddress::PUBKEY_ADDRESS_TEST + 128,
+    };
+
     void SetSecret(const CSecret& vchSecret, bool fCompressed)
     {
         assert(vchSecret.size() == 32);
-        SetData(128 + (fTestNet ? CBitcoinAddress::PUBKEY_ADDRESS_TEST : CBitcoinAddress::PUBKEY_ADDRESS), &vchSecret[0], vchSecret.size());
+        SetData(fTestNet ? PRIVKEY_ADDRESS_TEST : PRIVKEY_ADDRESS, &vchSecret[0], vchSecret.size());
         if (fCompressed)
             vchData.push_back(1);
     }
@@ -424,10 +430,10 @@ public:
         bool fExpectTestNet = false;
         switch(nVersion)
         {
-            case (128 + CBitcoinAddress::PUBKEY_ADDRESS):
+            case PRIVKEY_ADDRESS:
                 break;
 
-            case (128 + CBitcoinAddress::PUBKEY_ADDRESS_TEST):
+            case PRIVKEY_ADDRESS_TEST:
                 fExpectTestNet = true;
                 break;
 

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -250,7 +250,6 @@ public:
         return n;
     }
 
-
     void setvch(const std::vector<unsigned char>& vch)
     {
         std::vector<unsigned char> vch2(vch.size() + 4);

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       2
 #define CLIENT_VERSION_MINOR       0
 #define CLIENT_VERSION_REVISION    4
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_BUILD       1
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1155,7 +1155,7 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
     }
     // danbi: old pre 2.0.4 PoS pacing algorithm
     else if (fProofOfStake && GetTotalCoin() > POS_RESTART)
-    {       
+    {
         if(nActualSpacing < 0)
         {
             if (fDebug && GetBoolArg("-printjunk")) printf(">> %s nActualSpacing = %"PRI64d" corrected to 1.\n", fProofOfStake ? "PoS" : "PoW", nActualSpacing);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2140,8 +2140,8 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
         return DoS(100, error("CheckBlock() : size limits failed"));
 
     // Check proof of work matches claimed amount
-//    if (fCheckPOW && IsProofOfWork() && !CheckProofOfWork(GetHashScrypt(), nBits) && !CheckProofOfWork(GetHashGroestl(), nBits))
-    if (fCheckPOW && IsProofOfWork() && !CheckProofOfWork(GetHash(), nBits))
+    // XXX: danbi - need to check both algos or we make it hard for initial sync
+    if (fCheckPOW && IsProofOfWork() && !CheckProofOfWork(GetHashScrypt(), nBits) && !CheckProofOfWork(GetHashGroestl(), nBits))
         return DoS(50, error("CheckBlock() : proof of work failed"));
 
     // Check timestamp

--- a/src/makefile.bsd
+++ b/src/makefile.bsd
@@ -42,7 +42,7 @@ LIBS += \
    -l db_cxx$(BDB_LIB_SUFFIX) \
    -l ssl \
    -l crypto \
-   -l execinfo
+   -l execinfo -l elf
 
 ifndef USE_UPNP
 	override USE_UPNP = -

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -63,7 +63,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string notr="true">2.0.4</string>
+          <string notr="true">2.0.4.1</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -8,7 +8,7 @@
 // Name of client reported in the 'version' message. Report the same name
 // for both bitcoind and bitcoin-qt, to make it harder for attackers to
 // target servers or GUI users specifically.
-const std::string CLIENT_NAME("Diamond");
+const std::string CLIENT_NAME = "Diamond";
 
 // Client version number
 #define CLIENT_VERSION_SUFFIX   ""

--- a/src/version.h
+++ b/src/version.h
@@ -47,6 +47,6 @@ static const int MEMPOOL_GD_VERSION = 60002;
 #define DISPLAY_VERSION_MAJOR       2
 #define DISPLAY_VERSION_MINOR       0
 #define DISPLAY_VERSION_REVISION    4
-#define DISPLAY_VERSION_BUILD       0
+#define DISPLAY_VERSION_BUILD       1
 
 #endif


### PR DESCRIPTION
Fixes a bug that slows down initial block loading up to the Groestl algorithm switch.
Minor cleanup in the address processing code and whitespace.
Fixes to build on FreeBSD 10
