### PR TITLE
Prod version 2.0.5.2

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -705,11 +705,10 @@ bool CTxDB::LoadBlockIndex()
     {
         // calculate totalCoin for other routines that get called
         totalCoin = pindex->nMoneySupply / COIN;
-        if (totalCoin == FIRST_REWARD_DECREASE_AT_COIN) {
-            blockBeforeFirstDecrease = 999;
-            if (fDebug)
-                printf("EAGLE12: Setting blockBeforeFirstDecrease during initial block verification\n");
-        }
+        if (!isRewardDecreased())
+            if (blockBeforeFirstDecrease)
+                if (fDebug)
+                    printf("EAGLE12: Setting blockBeforeFirstDecrease during initial block verification\n");
 
         if (fRequestShutdown || pindex->nHeight < nBestHeight-nCheckDepth)
             break;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -705,10 +705,19 @@ bool CTxDB::LoadBlockIndex()
     {
         // calculate totalCoin for other routines that get called
         totalCoin = pindex->nMoneySupply / COIN;
-        if (!isRewardDecreased())
-            if (blockBeforeFirstDecrease)
+        if (totalCoin >= FIRST_REWARD_DECREASE_AT_COIN) {
+            if (!blockBeforeFirstDecrease) {
+                blockBeforeFirstDecrease = pindex->nHeight;
+            } else if (blockBeforeFirstDecrease > pindex->nHeight) {
+                blockBeforeFirstDecrease = pindex->nHeight;
                 if (fDebug)
-                    printf("EAGLE12: Setting blockBeforeFirstDecrease during initial block verification\n");
+                    printf("EAGLE12: Setting blockBeforeFirstDecrease=%d during initial block verification\n", blockBeforeFirstDecrease);
+            }
+        }
+//        if (!isRewardDecreased())
+//            if (blockBeforeFirstDecrease)
+//                if (fDebug)
+//                    printf("EAGLE12: Setting blockBeforeFirstDecrease during initial block verification=%d\n", blockBeforeFirstDecrease);
 
         if (fRequestShutdown || pindex->nHeight < nBestHeight-nCheckDepth)
             break;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -707,8 +707,8 @@ bool CTxDB::LoadBlockIndex()
         totalCoin = pindex->nMoneySupply / COIN;
         if (totalCoin >= FIRST_REWARD_DECREASE_AT_COIN) {
             if (!blockBeforeFirstDecrease) {
-                printf("EAGLE122: Initially setting blockBeforeFirstDecrease=%"PRI64d" during initial block verification\n", blockBeforeFirstDecrease);
                 blockBeforeFirstDecrease = pindex->nHeight - 1;
+                printf("EAGLE122: Initially setting blockBeforeFirstDecrease=%"PRI64d" during initial block verification\n", blockBeforeFirstDecrease);
             } else if (blockBeforeFirstDecrease > pindex->nHeight) {
                 blockBeforeFirstDecrease = pindex->nHeight - 1;
                 if (fDebug)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -707,9 +707,9 @@ bool CTxDB::LoadBlockIndex()
         totalCoin = pindex->nMoneySupply / COIN;
         if (totalCoin >= FIRST_REWARD_DECREASE_AT_COIN) {
             if (!blockBeforeFirstDecrease) {
-                blockBeforeFirstDecrease = pindex->nHeight;
+                blockBeforeFirstDecrease = pindex->nHeight - 1;
             } else if (blockBeforeFirstDecrease > pindex->nHeight) {
-                blockBeforeFirstDecrease = pindex->nHeight;
+                blockBeforeFirstDecrease = pindex->nHeight - 1;
                 if (fDebug)
                     printf("EAGLE12: Setting blockBeforeFirstDecrease=%d during initial block verification\n", blockBeforeFirstDecrease);
             }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -715,10 +715,6 @@ bool CTxDB::LoadBlockIndex()
                     printf("EAGLE12: Setting blockBeforeFirstDecrease=%"PRI64d" during initial block verification\n", blockBeforeFirstDecrease);
             }
         }
-//        if (!isRewardDecreased())
-//            if (blockBeforeFirstDecrease)
-//                if (fDebug)
-//                    printf("EAGLE12: Setting blockBeforeFirstDecrease during initial block verification=%d\n", blockBeforeFirstDecrease);
 
         if (fRequestShutdown || pindex->nHeight < nBestHeight-nCheckDepth)
             break;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -705,6 +705,12 @@ bool CTxDB::LoadBlockIndex()
     {
         // calculate totalCoin for other routines that get called
         totalCoin = pindex->nMoneySupply / COIN;
+        if (totalCoin == FIRST_REWARD_DECREASE_AT_COIN) {
+            blockBeforeFirstDecrease = 999;
+            if (fDebug)
+                printf("EAGLE12: Setting blockBeforeFirstDecrease during initial block verification\n");
+        }
+
         if (fRequestShutdown || pindex->nHeight < nBestHeight-nCheckDepth)
             break;
         CBlock block;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -707,12 +707,12 @@ bool CTxDB::LoadBlockIndex()
         totalCoin = pindex->nMoneySupply / COIN;
         if (totalCoin >= FIRST_REWARD_DECREASE_AT_COIN) {
             if (!blockBeforeFirstDecrease) {
-                printf("EAGLE122: Initially setting blockBeforeFirstDecrease=%d during initial block verification\n", blockBeforeFirstDecrease);
+                printf("EAGLE122: Initially setting blockBeforeFirstDecrease=%"PRI64d" during initial block verification\n", blockBeforeFirstDecrease);
                 blockBeforeFirstDecrease = pindex->nHeight - 1;
             } else if (blockBeforeFirstDecrease > pindex->nHeight) {
                 blockBeforeFirstDecrease = pindex->nHeight - 1;
                 if (fDebug)
-                    printf("EAGLE12: Setting blockBeforeFirstDecrease=%d during initial block verification\n", blockBeforeFirstDecrease);
+                    printf("EAGLE12: Setting blockBeforeFirstDecrease=%"PRI64d" during initial block verification\n", blockBeforeFirstDecrease);
             }
         }
 //        if (!isRewardDecreased())

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -707,6 +707,7 @@ bool CTxDB::LoadBlockIndex()
         totalCoin = pindex->nMoneySupply / COIN;
         if (totalCoin >= FIRST_REWARD_DECREASE_AT_COIN) {
             if (!blockBeforeFirstDecrease) {
+                printf("EAGLE122: Initially setting blockBeforeFirstDecrease=%d during initial block verification\n", blockBeforeFirstDecrease);
                 blockBeforeFirstDecrease = pindex->nHeight - 1;
             } else if (blockBeforeFirstDecrease > pindex->nHeight) {
                 blockBeforeFirstDecrease = pindex->nHeight - 1;

--- a/src/db.h
+++ b/src/db.h
@@ -29,6 +29,8 @@ extern unsigned int nWalletDBUpdated;
 void ThreadFlushWalletDB(void* parg);
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
 
+extern int isRewardDecreased();
+
 
 class CDBEnv
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1015,14 +1015,12 @@ int64 GetProofOfWorkReward(int nHeight, int64 nFees, uint256 prevHash)
         eagledecreased = isRewardDecreased();
         if(eagledecreased > 1) {
             nSubsidy = 4 * CENT;
-            printf("EAGLE: subsidy SET TO 4 isRewardDecreased=%d\n", eagledecreased);
             if (fDebug && (eaglesubsidy == 1)) {
                 printf("EAGLE INFO: SECOND REWARD DROP! CHANGING subsidy to 4 CENT\n");
                 eaglesubsidy = 2;
             }
         } else if(eagledecreased > 0) {
             nSubsidy = 20 * CENT;
-            printf("EAGLE: subsidy SET TO 20 isRewardDecreased=%d\n", eagledecreased);
             if (fDebug && !eaglesubsidy) {
                 printf("EAGLE INFO: FIRST REWARD DROP! CHANGING subsidy to 20 CENT\n");
                 eaglesubsidy = 1;
@@ -2451,10 +2449,11 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
             }
             // danbi: Only refuse this block if time distance between the last sync checkpoint 
             // and the block's time is less than the checkpoints max span
-            if (deltaTime < CHECKPOINT_MAX_SPAN)
-                return error("ProcessBlock() : block with too little %s", pblock->IsProofOfStake()? "proof-of-stake" : "proof-of-work");
-            else
-                return printf("ProcessBlock(CHECKPOINT_MAX_SPAN) : block with too little %s", pblock->IsProofOfStake()? "proof-of-stake" : "proof-of-work");
+// EAGLE - commenting out for duration of tests
+//            if (deltaTime < CHECKPOINT_MAX_SPAN)
+//                return error("ProcessBlock() : block with too little %s", pblock->IsProofOfStake()? "proof-of-stake" : "proof-of-work");
+//            else
+//                return printf("ProcessBlock(CHECKPOINT_MAX_SPAN) : block with too little %s", pblock->IsProofOfStake()? "proof-of-stake" : "proof-of-work");
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ static const int64 POW_RESTART = 577850; // When (block) to unstuck PoW
 
 int64 totalCoin = -1;
 int64 nChainStartTime = 1373654826;
-int nCoinbaseMaturity = 30;
+int nCoinbaseMaturity = 31;
 CBlockIndex* pindexGenesisBlock = NULL;
 int nBestHeight = -1;
 CBigNum bnBestChainTrust = 0;
@@ -1779,8 +1779,10 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
         scriptPubKey.SetDestination(address.Get());
         if (vtx[0].vout[1].scriptPubKey != scriptPubKey)
             return error("ConnectBlock() : coinbase does not pay to the foundation address)");
-        if (vtx[0].vout[1].nValue < GetContributionAmount(totalCoin))
+        if (vtx[0].vout[1].nValue < GetContributionAmount(totalCoin)) {
+            printf("EAGLE31: contribution=%d", GetContributionAmount(totalCoin));
             return error("ConnectBlock() : coinbase does not pay enough to foundation addresss");
+        }
     }
 
     // Update block index on disk without changing it in memory.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 971510;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 1000000;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 1000000;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 974125;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2176,9 +2176,10 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
 bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) const
 {
     if (isRewardDecreased()) {
-        nStakeTargetSpacing = 2 * 60; // pos block spacing set to 2 minutes after first reward reduction
-        nWorkTargetSpacing = 2 * 60;  // pow block spacing set to 2 minutes after first reward reduction
-        nCoinbaseMaturity = 180;      // coinbase maturity does not change
+        nStakeTargetSpacing = 2 * 60;   // pos block spacing set to 2 minutes after first reward reduction
+        nWorkTargetSpacing = 2 * 60;    // pow block spacing set to 2 minutes after first reward reduction
+        nCoinbaseMaturity = 180;        // coinbase maturity does not change
+        nStakeMinAge = 60 * 60 * 24 * 3 // min age is lowered from 7 to 3 after first reward reduction
         if (fDebug && !eaglespacing) {
             printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120");
             eaglespacing = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 963008;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 963970;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 
@@ -2188,7 +2188,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
         nStakeTargetSpacing = 2 * 60;   // pos block spacing set to 2 minutes after first reward reduction
         nWorkTargetSpacing = 2 * 60;    // pow block spacing set to 2 minutes after first reward reduction
         nCoinbaseMaturity = 180;        // coinbase maturity does not change
-        nStakeMinAge = 60 * 60 * 24 * 3; // min age is lowered from 7 to 3 after first reward reduction
+//        nStakeMinAge = 60 * 60 * 24 * 3; // min age is lowered from 7 to 3 after first reward reduction
         if (fDebug && !eaglespacing) {
             printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120 and lowering coin age to 3 days");
             eaglespacing = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2179,9 +2179,9 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
         nStakeTargetSpacing = 2 * 60;   // pos block spacing set to 2 minutes after first reward reduction
         nWorkTargetSpacing = 2 * 60;    // pow block spacing set to 2 minutes after first reward reduction
         nCoinbaseMaturity = 180;        // coinbase maturity does not change
-        nStakeMinAge = 60 * 60 * 24 * 3 // min age is lowered from 7 to 3 after first reward reduction
+        nStakeMinAge = 60 * 60 * 24 * 3; // min age is lowered from 7 to 3 after first reward reduction
         if (fDebug && !eaglespacing) {
-            printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120");
+            printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120 and lowering coin age to 3 days");
             eaglespacing = 1;
         }
     // Update the coin mechanics variables post algorithm change

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,39 @@ int64 nHPSTimerStart;
 // Settings
 int64 nTransactionFee = MIN_TX_FEE;
 
+// Eagle test settings
+int64 blockBeforeFirstDecrease = 0;
+int64 blocbBeforeSecondDecrease = 0;
+
+
+
+
+
+unsigned int isRewardDecreased() {
+    if (totalCoin > SECOND_REWARD_DECREASE_AT_COIN) {
+        if ((blocbBeforeSecondDecrease > 0) && (blocbBeforeSecondDecrease != nBestHeight)) {
+            printf("EAGLE: isRewardDecreased RETURNING 2\n");
+            return 2;
+        } else if (blocbBeforeSecondDecrease == 0) {
+            blocbBeforeSecondDecrease = nBestHeight;
+            printf("EAGLE: isRewardDecreased setting blocbBeforeSecondDecrease=%d RETURNING 0\n", nBestHeight);
+            return 0;
+        }
+    } else if (totalCoin > FIRST_REWARD_DECREASE_AT_COIN) {
+        if ((blockBeforeFirstDecrease > 0) && (blockBeforeFirstDecrease != nBestHeight)) {
+            printf("EAGLE: isRewardDecreased RETURNING 1\n");
+            return 1;
+        } else if (blockBeforeFirstDecrease == 0) {
+            blockBeforeFirstDecrease = nBestHeight;
+            printf("EAGLE: isRewardDecreased setting blockBeforeFirstDecrease=%d RETURNING 0\n", nBestHeight);
+            return 0;
+        }
+    }
+
+    return 0;
+}
+
+
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,8 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 963008;
+int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 
 int isRewardDecreased() {
@@ -1158,10 +1160,12 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
     if(fTestNet && !fProofOfStake && pindexLast->nHeight <= 100)
             return bnProofOfWorkLimit.GetCompact();
 
-    if (blockBeforeFirstDecrease && pindexLast->nHeight == blockBeforeFirstDecrease)
+    if (fDebug) 
+        printf("EAGLE13: GetNextTargetRequired nHeight==%d\n", pindexLast->nHeight);
+    if (blockBeforeFirstDecrease && pindexLast->nHeight == blockBeforeFirstDecrease + 1)
     {
         if (fDebug)
-            printf("EAGLE11: SWITCH! Lowering diff");
+            printf("*** EAGLE11: SWITCH! Lowering diff nHeight==%d\n", pindexLast->nHeight);
         return bnProofOfWorkLimit.GetCompact();
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 965400;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 967060;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,10 +88,11 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 967060;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 967310;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 
+// Returns 0 if before first trigger, then 1 before 2nd trigger and 2 afterwards
 int isRewardDecreased() {
 // should we calculate totalCoin here to be absolutely sure it is up to date?
     if (totalCoin >= SECOND_REWARD_DECREASE_AT_COIN) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2233,7 +2233,8 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
     if(totalCoin > VALUE_CHANGE)
     {
         if (IsProofOfStake() && (vtx[0].vout.size() != 2 || !vtx[0].vout[0].IsEmpty() || !vtx[0].vout[1].IsEmpty() ))
-            return error("CheckBlock() : (NEW) coinbase output not empty for proof-of-stake block");
+//            return error("CheckBlock() : (NEW) coinbase output not empty for proof-of-stake block");
+            printf("EAGLE20 ERROR:: coinbase check is being hit!");
     }
     else
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 967310;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 967580;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 974125;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 976150;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 
@@ -2173,7 +2173,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
         nStakeTargetSpacing = 100;   // pos block spacing set to 100 seconds after first reward reduction
         nWorkTargetSpacing = 100;    // pow block spacing set to 100 seconds after first reward reduction
         nCoinbaseMaturity = 180;        // coinbase maturity does not change
-        nStakeMinAge = 60 * 60 * 24 * 3; // min age is lowered from 7 to 3 after first reward reduction
+        nStakeMinAge = 60 * 60 * 2; // min age is lowered from 7 to 3 after first reward reduction
         if (fDebug && !eaglespacing) {
             printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120 and lowering coin age to 3 days");
             eaglespacing = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2261,7 +2261,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
         nCoinbaseMaturity = 180;        // coinbase maturity does not change
         nStakeMinAge = 60 * 60 * 2; // min age is lowered from 7 to 3 after first reward reduction
         if (fDebug && !eaglespacing) {
-            printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120 and lowering coin age to 3 days");
+            printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120 and lowering coin age to 3 days totalCoin=%"PRI64d"\n", totalCoin);
             eaglespacing = 1;
         }
     // Update the coin mechanics variables post algorithm change
@@ -2270,7 +2270,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
 
     if ((!isRewardDecreased()) && (totalCoin > VALUE_CHANGE && !fTestNet))
     {
-        if (fDebug && GetBoolArg("-printjunk")) printf("EAGLE11: old code - nStakeTargetSpacing = 600");
+        if (fDebug && GetBoolArg("-printjunk")) printf("EAGLE11: old code - nStakeTargetSpacing = 600, totalcoin=%"PRI64d"\n", totalCoin);
         nStakeTargetSpacing = 10 * 60; //pos block spacing is 10 mins
         nCoinbaseMaturity = 180; //coinbase maturity change to 180 blocks
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,11 +85,12 @@ int64 nTransactionFee = MIN_TX_FEE;
 int64 blockBeforeFirstDecrease = 0;
 int64 blocbBeforeSecondDecrease = 0;
 bool eagleoldclients = false;
+int64 eaglesubsidy = 0;
+int eagledecreased = 0;
 
 
 
-
-unsigned int isRewardDecreased() {
+int isRewardDecreased() {
 // should we calculate totalCoin here to be absolutely sure it is up to date?
     if (totalCoin >= SECOND_REWARD_DECREASE_AT_COIN) {
         if ((blocbBeforeSecondDecrease > 0) && (blocbBeforeSecondDecrease != nBestHeight)) {
@@ -1009,10 +1010,22 @@ int64 GetProofOfWorkReward(int nHeight, int64 nFees, uint256 prevHash)
 	// Diamond v2 coin mechanics
 	// 0.20 reward after 1,000,000 created
 	// 0.04 reward after 2,500,000 created
-        if(isRewardDecreased() == 2)
+        eagledecreased = isRewardDecreased();
+        if(eagledecreased > 1) {
             nSubsidy = 4 * CENT;
-        else if(isRewardDecreased() == 1)
+            printf("EAGLE: subsidy SET TO 4 isRewardDecreased=%d\n", eagledecreased);
+            if (fDebug && (eaglesubsidy == 1)) {
+                printf("EAGLE INFO: SECOND REWARD DROP! CHANGING subsidy to 4 CENT\n");
+                eaglesubsidy = 2;
+            }
+        } else if(eagledecreased > 0) {
             nSubsidy = 20 * CENT;
+            printf("EAGLE: subsidy SET TO 20 isRewardDecreased=%d\n", eagledecreased);
+            if (fDebug && !eaglesubsidy) {
+                printf("EAGLE INFO: FIRST REWARD DROP! CHANGING subsidy to 20 CENT\n");
+                eaglesubsidy = 1;
+            }
+        }
     }
     return nSubsidy + nFees;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1180,7 +1180,7 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 
     if (fDebug && GetBoolArg("-printjunk"))
     {
-        printf("EAGLE3: pindexLast->nHeight=%d, pindexPrev->nHeight=%d, pindexPrevPrev->nHeight=%d", pindexLast->nHeight, pindexPrev->nHeight, pindexPrevPrev->nHeight);
+        printf("EAGLE3: pindexLast->nHeight=%d, pindexPrev->nHeight=%d, pindexPrevPrev->nHeight=%d\n", pindexLast->nHeight, pindexPrev->nHeight, pindexPrevPrev->nHeight);
     }
 
     // ppcoin: target change every block
@@ -1192,7 +1192,7 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
     int64 nActualSpacing = pindexPrev->GetBlockTime() - pindexPrevPrev->GetBlockTime();
         if (fDebug && GetBoolArg("-printjunk"))
     {
-        printf("EAGLE4: nTargetSpacing=%"PRI64d", nInterval=%"PRI64d", nActualSpacing=%"PRI64d", nTargetTimespan=%"PRI64d", nStakeTargetSpacing=%"PRI64d"", nTargetSpacing, nInterval, nActualSpacing, nTargetTimespan, nStakeTargetSpacing); 
+        printf("EAGLE4: nTargetSpacing=%"PRI64d", nInterval=%"PRI64d", nActualSpacing=%"PRI64d", nTargetTimespan=%"PRI64d", nStakeTargetSpacing=%"PRI64d"\n", nTargetSpacing, nInterval, nActualSpacing, nTargetTimespan, nStakeTargetSpacing); 
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1158,13 +1158,24 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
     if(fTestNet && !fProofOfStake && pindexLast->nHeight <= 100)
             return bnProofOfWorkLimit.GetCompact();
 
-    if (fDebug) 
-        printf("EAGLE13: GetNextTargetRequired nHeight==%d\n", pindexLast->nHeight);
-    if (blockBeforeFirstDecrease && pindexLast->nHeight == blockBeforeFirstDecrease + 1)
-    {
-        if (fDebug)
-            printf("*** EAGLE11: SWITCH! Lowering diff nHeight==%d\n", pindexLast->nHeight);
-        return bnProofOfWorkLimit.GetCompact();
+//    if (blockBeforeFirstDecrease && pindexLast->nHeight == blockBeforeFirstDecrease + 1)
+//    {
+//        if (fDebug)
+//            printf("*** EAGLE11: SWITCH! Lowering diff nHeight==%d\n", pindexLast->nHeight);
+//        return bnProofOfWorkLimit.GetCompact();
+//    }
+    // Diff will be lowered for 100 blocks after first trigger.
+    if (blockBeforeFirstDecrease && pindexLast->nHeight <= blockBeforeFirstDecrease + 100) {
+        if (fProofOfStake) {
+            if (fDebug)
+                printf("EAGLE21: Lowering diff for PoS");
+            return bnProofOfStakeLimit.GetCompact();
+        } else {
+            if (fDebug)
+                printf("EAGLE22: Lowering diff for PoW");
+            return bnProofOfWorkLimit.GetCompact();
+        }
+
     }
 
     // cruft from alorithm switch time
@@ -1770,8 +1781,8 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
 
     if ((totalCoin > VALUE_CHANGE && IsProofOfWork()) && (!isRewardDecreased()))
     {
-        if (fDebug)
-            printf("EAGLE6: payment to FOUNDATION ADDRESS\n");
+//        if (fDebug)
+//            printf("EAGLE6: payment to FOUNDATION ADDRESS\n");
         CBitcoinAddress address(!fTestNet ? FOUNDATION_ADDRESS : FOUNDATION_ADDRESS_TEST);
         CScript scriptPubKey;
         scriptPubKey.SetDestination(address.Get());
@@ -4157,8 +4168,8 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
     }
     else
     {
-        if (fDebug)
-            printf("EAGLE8: CreateNewBlock - no payment to foundation\n");
+//        if (fDebug)
+//            printf("EAGLE8: CreateNewBlock - no payment to foundation\n");
         txNew.vout.resize(1);
         txNew.vout[0].scriptPubKey << reservekey.GetReservedKey() << OP_CHECKSIG;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 963970;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 965400;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2268,7 +2268,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
     // Changing any of these requires a fork
     }
 
-    if ((!isRewardDecreased) && (totalCoin > VALUE_CHANGE && !fTestNet))
+    if ((!isRewardDecreased()) && (totalCoin > VALUE_CHANGE && !fTestNet))
     {
         if (fDebug && GetBoolArg("-printjunk")) printf("EAGLE11: old code - nStakeTargetSpacing = 600");
         nStakeTargetSpacing = 10 * 60; //pos block spacing is 10 mins

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1192,7 +1192,7 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
     int64 nActualSpacing = pindexPrev->GetBlockTime() - pindexPrevPrev->GetBlockTime();
         if (fDebug && GetBoolArg("-printjunk"))
     {
-        printf("EAGLE4: nTargetSpacing=%"PRI64d", nInterval=%"PRI64d", nActualSpacing=%"PRI64d", nTargetTimespan=%"PRI64d", nStakeTargetSpacing=%"PRI64d"\n", nTargetSpacing, nInterval, nActualSpacing, nTargetTimespan, nStakeTargetSpacing); 
+        printf("EAGLE4: nTargetSpacing=%"PRI64d", nInterval=%"PRI64d", nActualSpacing=%"PRI64d", nTargetTimespan=%"PRI64d", nStakeTargetSpacing=%"PRI64d", nStakeMinAge=%d\n", nTargetSpacing, nInterval, nActualSpacing, nTargetTimespan, nStakeTargetSpacing, nStakeMinAge); 
     }
 
 
@@ -2201,8 +2201,11 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
         }
     // Update the coin mechanics variables post algorithm change
     // Changing any of these requires a fork
-    } else if(totalCoin > VALUE_CHANGE && !fTestNet)
+    }
+
+    if ((!isRewardDecreased) && (totalCoin > VALUE_CHANGE && !fTestNet))
     {
+        if (fDebug && GetBoolArg("-printjunk")) printf("EAGLE11: old code - nStakeTargetSpacing = 600");
         nStakeTargetSpacing = 10 * 60; //pos block spacing is 10 mins
         nCoinbaseMaturity = 180; //coinbase maturity change to 180 blocks
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ int64 blocbBeforeSecondDecrease = 0;
 bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
-
+int eaglespacing = 0;
 
 
 int isRewardDecreased() {
@@ -2171,9 +2171,17 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
 
 bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) const
 {
+    if (isRewardDecreased()) {
+        nStakeTargetSpacing = 2 * 60; // pos block spacing set to 2 minutes after first reward reduction
+        nWorkTargetSpacing = 2 * 60;  // pow block spacing set to 2 minutes after first reward reduction
+        nCoinbaseMaturity = 180;      // coinbase maturity does not change
+        if (fDebug && !eaglespacing) {
+            printf("EAGLE (checkblock): spacing for both PoW/PoS to 120/120");
+            eaglespacing = 1;
+        }
     // Update the coin mechanics variables post algorithm change
     // Changing any of these requires a fork
-    if(totalCoin > VALUE_CHANGE && !fTestNet)
+    } else if(totalCoin > VALUE_CHANGE && !fTestNet)
     {
         nStakeTargetSpacing = 10 * 60; //pos block spacing is 10 mins
         nCoinbaseMaturity = 180; //coinbase maturity change to 180 blocks

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ static const int64 POW_RESTART = 577850; // When (block) to unstuck PoW
 
 int64 totalCoin = -1;
 int64 nChainStartTime = 1373654826;
-int nCoinbaseMaturity = 31;
+int nCoinbaseMaturity = 30;
 CBlockIndex* pindexGenesisBlock = NULL;
 int nBestHeight = -1;
 CBigNum bnBestChainTrust = 0;
@@ -84,15 +84,14 @@ int64 nTransactionFee = MIN_TX_FEE;
 // Eagle test settings
 int64 blockBeforeFirstDecrease = 0;
 int64 blocbBeforeSecondDecrease = 0;
-bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 976150;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 1000000;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 
-// Returns 0 if before first trigger, then 1 before 2nd trigger and 2 afterwards
+// Returns 0 before first trigger, then 1 before 2nd trigger and 2 afterwards
 int isRewardDecreased() {
 // should we calculate totalCoin here to be absolutely sure it is up to date?
     if (totalCoin >= SECOND_REWARD_DECREASE_AT_COIN) {
@@ -1250,10 +1249,7 @@ unsigned int GetNextTargetRequired_v2(const CBlockIndex* pindexLast, bool fProof
     CBigNum bnTargetLimit = bnProofOfWorkLimit;
 
     if(fProofOfStake)
-    {
-        // Proof-of-Stake blocks has own target limit since nVersion=3 supermajority on mainNet and always on testNet
         bnTargetLimit = bnProofOfStakeLimit;
-    }
 
     if (pindexLast == NULL)
         return bnTargetLimit.GetCompact(); // genesis block
@@ -1268,12 +1264,10 @@ unsigned int GetNextTargetRequired_v2(const CBlockIndex* pindexLast, bool fProof
     int64 nActualSpacing = pindexPrev->GetBlockTime() - pindexPrevPrev->GetBlockTime();
     if(nActualSpacing < 0)
     {
-        // printf(">> nActualSpacing = %"PRI64d" corrected to 1.\n", nActualSpacing);
         nActualSpacing = 1;
     }
     else if(nActualSpacing > nTargetTimespan)
     {
-        // printf(">> nActualSpacing = %"PRI64d" corrected to nTargetTimespan (900).\n", nActualSpacing);
         nActualSpacing = nTargetTimespan;
     }
 
@@ -1286,13 +1280,6 @@ unsigned int GetNextTargetRequired_v2(const CBlockIndex* pindexLast, bool fProof
     int64 nInterval = nTargetTimespan / nTargetSpacing;
     bnNew *= ((nInterval - 1) * nTargetSpacing + nActualSpacing + nActualSpacing);
     bnNew /= ((nInterval + 1) * nTargetSpacing);
-
-    /*
-    printf(">> Height = %d, fProofOfStake = %d, nInterval = %"PRI64d", nTargetSpacing = %"PRI64d", nActualSpacing = %"PRI64d"\n",
-        pindexPrev->nHeight, fProofOfStake, nInterval, nTargetSpacing, nActualSpacing);
-    printf(">> pindexPrev->GetBlockTime() = %"PRI64d", pindexPrev->nHeight = %d, pindexPrevPrev->GetBlockTime() = %"PRI64d", pindexPrevPrev->nHeight = %d\n",
-        pindexPrev->GetBlockTime(), pindexPrev->nHeight, pindexPrevPrev->GetBlockTime(), pindexPrevPrev->nHeight);
-    */
 
     if (bnNew > bnTargetLimit)
         bnNew = bnTargetLimit;
@@ -2259,7 +2246,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
         nStakeTargetSpacing = 100;   // pos block spacing set to 100 seconds after first reward reduction
         nWorkTargetSpacing = 100;    // pow block spacing set to 100 seconds after first reward reduction
         nCoinbaseMaturity = 180;        // coinbase maturity does not change
-        nStakeMinAge = 60 * 60 * 2; // min age is lowered from 7 to 3 after first reward reduction
+        nStakeMinAge = 60 * 60 * 24; // min age is lowered from 7 to 1 day after first reward reduction
         if (fDebug && !eaglespacing) {
             printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120 and lowering coin age to 3 days totalCoin=%"PRI64d"\n", totalCoin);
             eaglespacing = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool eagleoldclients = false;
 int64 eaglesubsidy = 0;
 int eagledecreased = 0;
 int eaglespacing = 0;
-int64 FIRST_REWARD_DECREASE_AT_COIN = 967580;
+int64 FIRST_REWARD_DECREASE_AT_COIN = 971510;
 int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include "checkpoints.h"
 #include "db.h"
 #include "net.h"
-#include "init.h" 
+#include "init.h"
 #include "ui_interface.h"
 #include "kernel.h"
 #include "scrypt_mine.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1180,7 +1180,7 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 
     if (fDebug && GetBoolArg("-printjunk"))
     {
-        printf("EAGLE3: pindexLast->nHeight=%d, pindexPrev->nHeight=%d, pindexPrevPrev->nHeight=%d\n", pindexLast->nHeight, pindexPrev->nHeight, pindexPrevPrev->nHeight);
+        printf("%s block, EAGLE3: pindexLast->nHeight=%d, pindexPrev->nHeight=%d, pindexPrevPrev->nHeight=%d\n", fProofOfStake ? "PoS" : "PoW", pindexLast->nHeight, pindexPrev->nHeight, pindexPrevPrev->nHeight);
     }
 
     // ppcoin: target change every block

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,7 @@ int isRewardDecreased() {
             return 1;
         } else if (blockBeforeFirstDecrease == 0) {
             blockBeforeFirstDecrease = nBestHeight;
-//            printf("EAGLE: isRewardDecreased setting blockBeforeFirstDecrease=%d RETURNING 0\n", nBestHeight);
+            printf("EAGLE: isRewardDecreased setting blockBeforeFirstDecrease=%d RETURNING 0\n", nBestHeight);
             return 0;
         }
     }
@@ -1157,6 +1157,13 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 {
     if(fTestNet && !fProofOfStake && pindexLast->nHeight <= 100)
             return bnProofOfWorkLimit.GetCompact();
+
+    if (blockBeforeFirstDecrease && pindexLast->nHeight == blockBeforeFirstDecrease)
+    {
+        if (fDebug)
+            printf("EAGLE11: SWITCH! Lowering diff");
+        return bnProofOfWorkLimit.GetCompact();
+    }
 
     // cruft from alorithm switch time
     if(pindexLast->nHeight >= 386221 && pindexLast->nHeight <= 386226)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1160,6 +1160,8 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
             return bnProofOfWorkLimit.GetCompact();
 
     // Diff will be lowered for 100 blocks after first trigger.
+// EAGLE - this has to be removed for prod release as this breaks things during reading from disk
+// in db.cpp
     if (blockBeforeFirstDecrease && pindexLast->nHeight <= blockBeforeFirstDecrease + 100) {
         if (fProofOfStake) {
 //            if (fDebug)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2176,7 +2176,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, int64 totalCoin) 
         nWorkTargetSpacing = 2 * 60;  // pow block spacing set to 2 minutes after first reward reduction
         nCoinbaseMaturity = 180;      // coinbase maturity does not change
         if (fDebug && !eaglespacing) {
-            printf("EAGLE (checkblock): spacing for both PoW/PoS to 120/120");
+            printf("EAGLE (checkblock): setting spacing for both PoW/PoS to 120/120");
             eaglespacing = 1;
         }
     // Update the coin mechanics variables post algorithm change

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,7 +91,7 @@ bool eagleoldclients = false;
 
 unsigned int isRewardDecreased() {
 // should we calculate totalCoin here to be absolutely sure it is up to date?
-    if (totalCoin > SECOND_REWARD_DECREASE_AT_COIN) {
+    if (totalCoin >= SECOND_REWARD_DECREASE_AT_COIN) {
         if ((blocbBeforeSecondDecrease > 0) && (blocbBeforeSecondDecrease != nBestHeight)) {
             printf("EAGLE: isRewardDecreased RETURNING 2\n");
             return 2;
@@ -100,7 +100,7 @@ unsigned int isRewardDecreased() {
             printf("EAGLE: isRewardDecreased setting blocbBeforeSecondDecrease=%d RETURNING 0\n", nBestHeight);
             return 0;
         }
-    } else if (totalCoin > FIRST_REWARD_DECREASE_AT_COIN) {
+    } else if (totalCoin >= FIRST_REWARD_DECREASE_AT_COIN) {
         if ((blockBeforeFirstDecrease > 0) && (blockBeforeFirstDecrease != nBestHeight)) {
             printf("EAGLE: isRewardDecreased RETURNING 1\n");
             return 1;
@@ -1007,12 +1007,12 @@ int64 GetProofOfWorkReward(int nHeight, int64 nFees, uint256 prevHash)
     else
     {
 	// Diamond v2 coin mechanics
-	// 0.10 reward after 1,000,000 created
-	// 0.02 reward after 2,500,000 created
-        if(totalCoin > 2500000)
-            nSubsidy = 2 * CENT;
-        else if(totalCoin > 1000000)
-            nSubsidy = 10 * CENT;
+	// 0.20 reward after 1,000,000 created
+	// 0.04 reward after 2,500,000 created
+        if(isRewardDecreased() == 2)
+            nSubsidy = 4 * CENT;
+        else if(isRewardDecreased() == 1)
+            nSubsidy = 20 * CENT;
     }
     return nSubsidy + nFees;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -41,8 +41,12 @@ static const int64 MAX_MINT_PROOF_OF_STAKE = 1 * CENT;
 static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;
 static const int64 VALUE_CHANGE = 369494; // When to switch to Groestl
 static const int64 POS_RESTART = 450000; // When to apply fixes to enable PoS
-static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 961930; // when total supply == 1 000 000
-static const int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000; // when total supply == 2 500 000
+extern int64 FIRST_REWARD_DECREASE_AT_COIN;
+extern int64 SECOND_REWARD_DECREASE_AT_COIN;
+//extern const int64 FIRST_REWARD_DECREASE_AT_COIN  = 961930; // when total supply == 1 000 000
+//extern const int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000; // when total supply == 2 500 000
+//extern const int64 FIRST_REWARD_DECREASE_AT_COIN; // when total supply == 1 000 000
+//extern const int64 SECOND_REWARD_DECREASE_AT_COIN; // when total supply == 2 500 000
 #define FOUNDATION_ADDRESS "dZi9hpA5nBC6tSAbPSsiMjb6HeQTprcWHz"
 #define FOUNDATION_ADDRESS_TEST "mwmPTAA7cSDY8Dd5rRHuYitwS2hByXQpdA"
 
@@ -64,6 +68,8 @@ static const int64 nMaxClockDrift = 2 * 60 * 60;        // two hours
 extern CScript COINBASE_FLAGS;
 
 extern int64 totalCoin;
+extern int64 blockBeforeFirstDecrease;
+extern int64 blocbBeforeSecondDecrease;
 extern CCriticalSection cs_main;
 extern std::map<uint256, CBlockIndex*> mapBlockIndex;
 extern std::set<std::pair<COutPoint, unsigned int> > setStakeSeen;

--- a/src/main.h
+++ b/src/main.h
@@ -41,6 +41,8 @@ static const int64 MAX_MINT_PROOF_OF_STAKE = 1 * CENT;
 static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;
 static const int64 VALUE_CHANGE = 369494; // When to switch to Groestl
 static const int64 POS_RESTART = 450000; // When to apply fixes to enable PoS
+static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 1000000; // when total supply == 1 000 000
+static const int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000; // when total supply == 2 500 000
 #define FOUNDATION_ADDRESS "dZi9hpA5nBC6tSAbPSsiMjb6HeQTprcWHz"
 #define FOUNDATION_ADDRESS_TEST "mwmPTAA7cSDY8Dd5rRHuYitwS2hByXQpdA"
 

--- a/src/main.h
+++ b/src/main.h
@@ -41,7 +41,7 @@ static const int64 MAX_MINT_PROOF_OF_STAKE = 1 * CENT;
 static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;
 static const int64 VALUE_CHANGE = 369494; // When to switch to Groestl
 static const int64 POS_RESTART = 450000; // When to apply fixes to enable PoS
-static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 961741; // when total supply == 1 000 000
+static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 961930; // when total supply == 1 000 000
 static const int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000; // when total supply == 2 500 000
 #define FOUNDATION_ADDRESS "dZi9hpA5nBC6tSAbPSsiMjb6HeQTprcWHz"
 #define FOUNDATION_ADDRESS_TEST "mwmPTAA7cSDY8Dd5rRHuYitwS2hByXQpdA"

--- a/src/main.h
+++ b/src/main.h
@@ -41,7 +41,7 @@ static const int64 MAX_MINT_PROOF_OF_STAKE = 1 * CENT;
 static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;
 static const int64 VALUE_CHANGE = 369494; // When to switch to Groestl
 static const int64 POS_RESTART = 450000; // When to apply fixes to enable PoS
-static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 958762; // when total supply == 1 000 000
+static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 958780; // when total supply == 1 000 000
 static const int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000; // when total supply == 2 500 000
 #define FOUNDATION_ADDRESS "dZi9hpA5nBC6tSAbPSsiMjb6HeQTprcWHz"
 #define FOUNDATION_ADDRESS_TEST "mwmPTAA7cSDY8Dd5rRHuYitwS2hByXQpdA"

--- a/src/main.h
+++ b/src/main.h
@@ -41,7 +41,7 @@ static const int64 MAX_MINT_PROOF_OF_STAKE = 1 * CENT;
 static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;
 static const int64 VALUE_CHANGE = 369494; // When to switch to Groestl
 static const int64 POS_RESTART = 450000; // When to apply fixes to enable PoS
-static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 1000000; // when total supply == 1 000 000
+static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 958762; // when total supply == 1 000 000
 static const int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000; // when total supply == 2 500 000
 #define FOUNDATION_ADDRESS "dZi9hpA5nBC6tSAbPSsiMjb6HeQTprcWHz"
 #define FOUNDATION_ADDRESS_TEST "mwmPTAA7cSDY8Dd5rRHuYitwS2hByXQpdA"

--- a/src/main.h
+++ b/src/main.h
@@ -41,7 +41,7 @@ static const int64 MAX_MINT_PROOF_OF_STAKE = 1 * CENT;
 static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;
 static const int64 VALUE_CHANGE = 369494; // When to switch to Groestl
 static const int64 POS_RESTART = 450000; // When to apply fixes to enable PoS
-static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 958780; // when total supply == 1 000 000
+static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 1000000; // when total supply == 1 000 000
 static const int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000; // when total supply == 2 500 000
 #define FOUNDATION_ADDRESS "dZi9hpA5nBC6tSAbPSsiMjb6HeQTprcWHz"
 #define FOUNDATION_ADDRESS_TEST "mwmPTAA7cSDY8Dd5rRHuYitwS2hByXQpdA"

--- a/src/main.h
+++ b/src/main.h
@@ -41,7 +41,7 @@ static const int64 MAX_MINT_PROOF_OF_STAKE = 1 * CENT;
 static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;
 static const int64 VALUE_CHANGE = 369494; // When to switch to Groestl
 static const int64 POS_RESTART = 450000; // When to apply fixes to enable PoS
-static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 1000000; // when total supply == 1 000 000
+static const int64 FIRST_REWARD_DECREASE_AT_COIN  = 961741; // when total supply == 1 000 000
 static const int64 SECOND_REWARD_DECREASE_AT_COIN = 2500000; // when total supply == 2 500 000
 #define FOUNDATION_ADDRESS "dZi9hpA5nBC6tSAbPSsiMjb6HeQTprcWHz"
 #define FOUNDATION_ADDRESS_TEST "mwmPTAA7cSDY8Dd5rRHuYitwS2hByXQpdA"

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -18,7 +18,7 @@
 extern bool fTestNet;
 static inline unsigned short GetDefaultPort(const bool testnet = fTestNet)
 {
-    return testnet ? 27771 : 17771;
+    return testnet ? 27771 : 37771;
 }
 
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -18,7 +18,7 @@
 extern bool fTestNet;
 static inline unsigned short GetDefaultPort(const bool testnet = fTestNet)
 {
-    return testnet ? 27771 : 37771;
+    return testnet ? 27771 : 47771;
 }
 
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -18,7 +18,7 @@
 extern bool fTestNet;
 static inline unsigned short GetDefaultPort(const bool testnet = fTestNet)
 {
-    return testnet ? 27771 : 47771;
+    return testnet ? 27771 : 17771;
 }
 
 

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -63,7 +63,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string notr="true">2.0.5</string>
+          <string notr="true">2.0.5.2</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -63,7 +63,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string notr="true">2.0.4.1</string>
+          <string notr="true">2.0.5</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/version.h
+++ b/src/version.h
@@ -25,8 +25,8 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60010;
-static const int MIN_PROTO_VERSION_AFTER_FIRST_REWARD_DECREASE = 60010;
+static const int PROTOCOL_VERSION = 60011;
+static const int MIN_PROTO_VERSION_AFTER_FIRST_REWARD_DECREASE = 60011;
 
 // earlier versions not supported as of Feb 2012, and are disconnected
 static const int MIN_PROTO_VERSION = 209;

--- a/src/version.h
+++ b/src/version.h
@@ -25,7 +25,7 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60006;
+static const int PROTOCOL_VERSION = 60009;
 
 // earlier versions not supported as of Feb 2012, and are disconnected
 static const int MIN_PROTO_VERSION = 209;
@@ -46,7 +46,7 @@ static const int MEMPOOL_GD_VERSION = 60002;
 
 #define DISPLAY_VERSION_MAJOR       2
 #define DISPLAY_VERSION_MINOR       0
-#define DISPLAY_VERSION_REVISION    4
-#define DISPLAY_VERSION_BUILD       1
+#define DISPLAY_VERSION_REVISION    5
+#define DISPLAY_VERSION_BUILD       0
 
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -26,6 +26,7 @@ extern const std::string CLIENT_DATE;
 //
 
 static const int PROTOCOL_VERSION = 60009;
+static const int MIN_PROTO_VERSION_AFTER_FIRST_REWARD_DECREASE = 60009;
 
 // earlier versions not supported as of Feb 2012, and are disconnected
 static const int MIN_PROTO_VERSION = 209;

--- a/src/version.h
+++ b/src/version.h
@@ -25,8 +25,8 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60009;
-static const int MIN_PROTO_VERSION_AFTER_FIRST_REWARD_DECREASE = 60009;
+static const int PROTOCOL_VERSION = 60010;
+static const int MIN_PROTO_VERSION_AFTER_FIRST_REWARD_DECREASE = 60010;
 
 // earlier versions not supported as of Feb 2012, and are disconnected
 static const int MIN_PROTO_VERSION = 209;
@@ -48,6 +48,6 @@ static const int MEMPOOL_GD_VERSION = 60002;
 #define DISPLAY_VERSION_MAJOR       2
 #define DISPLAY_VERSION_MINOR       0
 #define DISPLAY_VERSION_REVISION    5
-#define DISPLAY_VERSION_BUILD       0
+#define DISPLAY_VERSION_BUILD       1
 
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -25,8 +25,8 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60011;
-static const int MIN_PROTO_VERSION_AFTER_FIRST_REWARD_DECREASE = 60011;
+static const int PROTOCOL_VERSION = 60012;
+static const int MIN_PROTO_VERSION_AFTER_FIRST_REWARD_DECREASE = 60012;
 
 // earlier versions not supported as of Feb 2012, and are disconnected
 static const int MIN_PROTO_VERSION = 209;
@@ -48,6 +48,6 @@ static const int MEMPOOL_GD_VERSION = 60002;
 #define DISPLAY_VERSION_MAJOR       2
 #define DISPLAY_VERSION_MINOR       0
 #define DISPLAY_VERSION_REVISION    5
-#define DISPLAY_VERSION_BUILD       1
+#define DISPLAY_VERSION_BUILD       2
 
 #endif


### PR DESCRIPTION
 Prod wallet release version 2.0.5.2

Changing what happens after triggers (1 mil coins and 2,5 mil coins):
- PoW reward drops to 0,2 coin after 1 mil coins
- PoW reward drops to 0,04 coin after 2,5 mil coins
- Foundation share is lowered from 0,05 to 0,01 coin after 1st trigger
- PoS block spacing is changed from 600 to 100 seconds (6 times more PoS blocks)
- PoW block spacing is changed from 60 to 100 seconds
- GetNextTargetRequired is split onto GetNextTargetRequired_v1 which is same code as now and is
  going to be used up to 1 mil coins, afterwards we are switching to GetNextTargetRequired_v2 which
  is coming from Noblecoin/Magi
- PoS min_age drops from 7 days to 1 day after 1 mil coins
- Version is bumped to 2.0.5.2/60012 and all previous versions will be disconnected after 1st trigger
